### PR TITLE
logger: dotenvダンプの秘密漏洩・panic・データ競合を修正 (#16)

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -57,3 +57,9 @@ fmt.Println(getenv.Duration("ANY_ENV", "1h30m20s"))
 18h12m16s
 18h12m16s
 ```
+
+# dotenv ダンプ
+
+`GETENV_DUMP_MODE=dotenv` を設定すると、各アクセサが読み取った環境変数ごとに `KEY=` 行を出力します. `.env` テンプレートの生成に便利です.
+
+デフォルト値は既定で**マスク**されます(`KEY=`). デフォルト値に誤って秘密情報を渡してもダンプ先に漏れないようにするためです. デフォルト値も出力したい場合は `getenv.Logger.DumpValues(true)` を呼び出してください. 出力先は `getenv.Logger.SetWriter(w)` で変更できます.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ fmt.Println(getenv.Duration("ANY_ENV", "1h30m20s"))
 60h0m0s
 60h0m0s
 ```
+
+# dotenv dump
+
+Setting `GETENV_DUMP_MODE=dotenv` makes every accessor emit a `KEY=` line for each
+environment variable it reads, which is handy for generating a `.env` template.
+
+Default values are **masked** (`KEY=`) so that secrets accidentally passed as a default
+are not leaked to the dump target. Call `getenv.Logger.DumpValues(true)` to include the
+default values, and `getenv.Logger.SetWriter(w)` to redirect the output.

--- a/logger.go
+++ b/logger.go
@@ -1,10 +1,13 @@
 package getenv
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"reflect"
+	"sync"
 )
 
 var Logger = &EnvLogger{
@@ -12,60 +15,72 @@ var Logger = &EnvLogger{
 }
 
 type EnvLogger struct {
-	w io.Writer
+	mu         sync.Mutex
+	w          io.Writer
+	dumpValues bool
 }
 
 func (l *EnvLogger) SetWriter(w io.Writer) {
+	l.mu.Lock()
 	l.w = w
+	l.mu.Unlock()
+}
+
+// DumpValues controls whether the dotenv dump output includes the
+// (developer-provided) default values.
+//
+// It is disabled by default so that secrets accidentally placed in default values
+// are not written to the dump target. Enable it explicitly only when the defaults
+// are known to be non-sensitive.
+func (l *EnvLogger) DumpValues(enabled bool) {
+	l.mu.Lock()
+	l.dumpValues = enabled
+	l.mu.Unlock()
 }
 
 func (l *EnvLogger) Dump(key string, def ...interface{}) {
 	switch os.Getenv("GETENV_DUMP_MODE") {
 	case "dotenv":
 		if err := l.dumpDotEnv(key, def...); err != nil {
-			panic(err)
+			// A logging side effect must never crash the host program, so the
+			// write error is reported best-effort instead of panicking.
+			log.Printf("getenv: dump error: %v", err)
 		}
 	}
 }
 
 func (l *EnvLogger) dumpDotEnv(key string, def ...interface{}) error {
-	if _, err := l.w.Write([]byte(key)); err != nil {
-		return err
-	}
-	if _, err := l.w.Write([]byte("=")); err != nil {
-		return err
-	}
-	if len(def) == 0 {
-		if _, err := l.w.Write([]byte("\n")); err != nil {
-			return err
-		}
-		return nil
-	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-	if def[0] == nil {
-		if _, err := l.w.Write([]byte("\n")); err != nil {
-			return err
-		}
-		return nil
+	// Build the whole record first and emit it with a single Write so concurrent
+	// dumps cannot interleave into corrupted lines.
+	var b bytes.Buffer
+	b.WriteString(key)
+	b.WriteByte('=')
+	if l.dumpValues {
+		b.WriteString(formatDefault(def...))
 	}
+	b.WriteByte('\n')
 
-	var v interface{}
-	switch reflect.TypeOf(def[0]).Kind() {
-	case reflect.Slice:
-		s := reflect.ValueOf(def[0])
+	_, err := l.w.Write(b.Bytes())
+	return err
+}
+
+// formatDefault renders the first default value for dotenv output. Slice defaults
+// render their first element, mirroring the historical behaviour. It returns an
+// empty string when there is no usable default.
+func formatDefault(def ...interface{}) string {
+	if len(def) == 0 || def[0] == nil {
+		return ""
+	}
+	v := def[0]
+	if reflect.TypeOf(v).Kind() == reflect.Slice {
+		s := reflect.ValueOf(v)
 		if s.Len() == 0 {
-			if _, err := l.w.Write([]byte("\n")); err != nil {
-				return err
-			}
-			return nil
+			return ""
 		}
 		v = s.Index(0).Interface()
-	default:
-		v = def[0]
 	}
-	if _, err := l.w.Write([]byte(fmt.Sprintf("%v\n", v))); err != nil {
-		return err
-	}
-
-	return nil
+	return fmt.Sprintf("%v", v)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,123 @@
+package getenv
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+
+// useDumpLogger points the global Logger at the given writer with dotenv dump mode
+// enabled, and restores the defaults afterwards.
+func useDumpLogger(t *testing.T, w io.Writer, dumpValues bool) {
+	t.Helper()
+	t.Setenv("GETENV_DUMP_MODE", "dotenv")
+	Logger.SetWriter(w)
+	Logger.DumpValues(dumpValues)
+	t.Cleanup(func() {
+		Logger.SetWriter(os.Stdout)
+		Logger.DumpValues(false)
+	})
+}
+
+func TestDumpMasksValuesByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	useDumpLogger(t, &buf, false)
+
+	String("API_KEY", "sk-live-secret")
+
+	assert.Equal(t, "API_KEY=\n", buf.String())
+	assert.NotContains(t, buf.String(), "sk-live-secret")
+}
+
+func TestDumpShowsValuesWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	useDumpLogger(t, &buf, true)
+
+	String("STR_ENV", "hoge")
+
+	assert.Equal(t, "STR_ENV=hoge\n", buf.String())
+}
+
+func TestDumpSliceMaskedByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	useDumpLogger(t, &buf, false)
+
+	StringSlice("HOSTS", []string{"secret1", "secret2", "secret3"})
+
+	assert.Equal(t, "HOSTS=\n", buf.String())
+	assert.NotContains(t, buf.String(), "secret")
+}
+
+func TestDumpSliceShownWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	useDumpLogger(t, &buf, true)
+
+	StringSlice("HOSTS", []string{"a", "b", "c"})
+
+	assert.Equal(t, "HOSTS=[a b c]\n", buf.String())
+}
+
+func TestDumpDoesNotPanicOnWriteError(t *testing.T) {
+	useDumpLogger(t, errWriter{}, true)
+
+	assert.NotPanics(t, func() {
+		got := String("SOME_KEY", "default")
+		assert.Equal(t, "default", got)
+	})
+}
+
+// TestDumpConcurrent exercises concurrent dumps while the writer is swapped, to be
+// run under `go test -race`. It also asserts that records are never interleaved.
+func TestDumpConcurrent(t *testing.T) {
+	var mu sync.Mutex
+	lines := map[string]struct{}{}
+	collector := writerFunc(func(p []byte) (int, error) {
+		mu.Lock()
+		lines[string(p)] = struct{}{}
+		mu.Unlock()
+		return len(p), nil
+	})
+
+	useDumpLogger(t, collector, true)
+
+	var wg sync.WaitGroup
+	const n = 200
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			String("KEY", "val")
+		}()
+	}
+	// Concurrently swap the writer to surface any data race on Logger.w.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Logger.SetWriter(collector)
+		}()
+	}
+	wg.Wait()
+
+	// Every record arrives as a single, well-formed write; no interleaving.
+	mu.Lock()
+	defer mu.Unlock()
+	for line := range lines {
+		assert.Equal(t, "KEY=val\n", line)
+		assert.Equal(t, 1, strings.Count(line, "\n"))
+	}
+}
+
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }


### PR DESCRIPTION
## 概要
`logger.go` の dotenv ダンプ経路(`GETENV_DUMP_MODE=dotenv`)に集中していた、秘密漏洩フットガン・panic・データ競合・出力破損をまとめて修正します。

Closes #16

## 背景
セキュリティ監査(敵対的検証済み)で、以下が検出されていました(いずれも opt-in なデバッグ経路ゲートのため深刻度 low ですが、ライブラリがロギング副作用で秘密を漏らしたりホストをクラッシュさせるべきではありません)。

- **#1 / #2** デフォルト値(秘密になり得る)を stdout に出力(スライス型も含む)
- **#3** 書き込みエラーで `panic` し全アクセサに伝播 → ホストプロセス DoS
- **#4** グローバル `Logger.w` が無ロックで `SetWriter` とデータ競合
- **#5** 1 レコードを複数 `Write` に分割しており並行時に行が交錯(監査で 400 行中 153 行破損を実測)

## 変更点
- **secure by default**: ダンプのデフォルト値出力を既定で**マスク**(`KEY=`)し、`Logger.DumpValues(true)` で明示的に opt-in したときのみ実値を出力(#1 / #2)
- `Dump` の書き込みエラーを `panic` から**ベストエフォートの `log.Printf`** に変更(#3)
- `Logger.w` / `dumpValues` を `sync.Mutex` で保護(#4)
- 1 レコードを `bytes.Buffer` で組み立て**単一 `Write`** に集約(#5)
- `logger_test.go` を追加:マスク既定 / opt-in / スライス / panic 回避 / 並行(`-race`・行の非交錯)を検証
- README(en/jp)に dotenv ダンプ機能と `DumpValues` を追記(従来は未記載)

## 補足(スコープ外)
- **#14**(`os.Getenv` を毎回読む): `example.go` が実行時に `GETENV_DUMP_MODE` をセットして使う動作に依存するため、init キャッシュ化は破壊的。info かつ実害なし(Go 1.21 では O(1))のため**据え置き**。

## 挙動変更(破壊的の可能性)
- `GETENV_DUMP_MODE=dotenv` の出力が `KEY=<デフォルト値>` → `KEY=`(マスク)に変わります。従来どおり値を出したい場合は `getenv.Logger.DumpValues(true)` を呼んでください。dotenv ダンプは README 未記載のデバッグ機能のため影響は限定的と判断しています。

## テスト
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `go test -race ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
