### PR TITLE
ci: GITHUB_TOKEN権限の最小化とActionsのSHAピン留め (#19)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: .go-version
 


### PR DESCRIPTION
## 概要
CI ワークフローのサプライチェーン/権限ハードニングと、Node.js 20 deprecated 警告の解消をまとめて行います。

Closes #19

## 背景(監査検出 + CI 警告)
- **#11** ワークフローに `permissions:` が無く、`GITHUB_TOKEN` がリポジトリ既定(しばしば read-write)にフォールバック。ジョブは `go test` のみで `contents: read` で十分
- **#12** `actions/checkout@v4` / `actions/setup-go@v5` が可変タグ参照。タグ乗っ取り/リポジトリ侵害時に攻撃者コードが透過的に走る
- 直近の CI で `actions/checkout@v4` / `actions/setup-go@v5` が **Node.js 20 deprecated**(2026-09-16 削除予定)の警告を出していた

## 変更点
- **最小権限を明示**: トップレベルに `permissions: contents: read`(#11)
- **Actions を SHA ピン留め**(#12):
  - `actions/checkout` → `df4cb1c069e1874edd31b4311f1884172cec0e10` # v6.0.3
  - `actions/setup-go` → `4a3601121dd01d1626a1e23e37211e3254c1c06c` # v6.4.0
  - いずれも `runs.using: node24` を確認済み → **Node.js 20 deprecated も解消**
- **Dependabot 追加**(`.github/dependabot.yml`): `github-actions` を weekly 更新し、SHA ピンの陳腐化を防止

## 検証
- ピンした SHA が各リリースタグ(v6.0.3 / v6.4.0)に解決されることを GitHub API で確認済み
- `test.yml` / `dependabot.yml` の YAML 妥当性を確認済み
- マージ前の本 PR の CI 実行が、ピン留め後ワークフローの動作確認を兼ねます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
