### PR TITLE
parse: パースエラーログに生のenv値を出力しない (#20)

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -52,7 +52,9 @@ func Duration(key string, def ...interface{}) time.Duration {
 	}
 	parsed, err := time.ParseDuration(v)
 	if err != nil {
-		log.Printf("getenv: failed to parse %q as duration: %v", key, err)
+		// time.ParseDuration embeds the raw value in its error message, so log only
+		// the key to avoid leaking a potentially sensitive environment value.
+		log.Printf("getenv: failed to parse value for %q as duration", key)
 		return d
 	}
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,16 +1,20 @@
 package getenv
 
 import (
+	"bytes"
+	"log"
+	"os"
 	"testing"
 	"time"
-	"os"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDuration(t *testing.T) {
 	tests := []struct {
 		input string
-		def interface{}
-		want time.Duration
+		def   interface{}
+		want  time.Duration
 	}{
 		{"", "", 0},
 		{"", 0, 0},
@@ -18,7 +22,7 @@ func TestDuration(t *testing.T) {
 		{"", 60, 60 * time.Second},
 		{"", time.Duration(60), time.Duration(60)},
 		{"", "60s", 60 * time.Second},
-		{"60s", nil, 60*time.Second},
+		{"60s", nil, 60 * time.Second},
 		{"a", nil, 0},
 		{"a", 60, 60 * time.Second},
 		// numeric default types are interpreted as seconds
@@ -42,4 +46,21 @@ func TestDuration(t *testing.T) {
 		}
 		os.Unsetenv(key)
 	}
+}
+
+// TestDurationEnvParseErrorDoesNotLogRawValue ensures an invalid env value falls back
+// to the default without leaking the raw value into the log (time.ParseDuration would
+// otherwise embed it in its error message).
+func TestDurationEnvParseErrorDoesNotLogRawValue(t *testing.T) {
+	const raw = "garbage-SECRET-duration"
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	t.Setenv("DUR_ENV", raw)
+
+	got := Duration("DUR_ENV", 5*time.Second)
+
+	assert.Equal(t, 5*time.Second, got, "should fall back to default")
+	assert.NotContains(t, buf.String(), raw, "raw env value must not be logged")
+	assert.Contains(t, buf.String(), "DUR_ENV", "key should be logged")
 }

--- a/int.go
+++ b/int.go
@@ -1,6 +1,7 @@
 package getenv
 
 import (
+	"errors"
 	"log"
 	"os"
 	"strconv"
@@ -18,7 +19,7 @@ func Int(key string, def ...int) int {
 	}
 	i, err := strconv.Atoi(v)
 	if err != nil {
-		log.Printf("parse error: input: %v, %v\n", v, err.Error())
+		log.Printf("getenv: failed to parse %q as int: %v", key, parseErrReason(err))
 		return d
 	}
 	return i
@@ -36,7 +37,7 @@ func Int32(key string, def ...int32) int32 {
 	}
 	i32, err := strconv.ParseInt(v, 10, 32)
 	if err != nil {
-		log.Printf("parse error: input: %v, %v\n", v, err.Error())
+		log.Printf("getenv: failed to parse %q as int32: %v", key, parseErrReason(err))
 		return d
 	}
 	return int32(i32)
@@ -54,7 +55,7 @@ func Int64(key string, def ...int64) int64 {
 	}
 	i64, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		log.Printf("parse error: input: %v, %v\n", v, err.Error())
+		log.Printf("getenv: failed to parse %q as int64: %v", key, parseErrReason(err))
 		return d
 	}
 	return int64(i64)
@@ -72,8 +73,20 @@ func Int16(key string, def ...int16) int16 {
 	}
 	i16, err := strconv.ParseInt(v, 10, 16)
 	if err != nil {
-		log.Printf("parse error: input: %v, %v\n", v, err.Error())
+		log.Printf("getenv: failed to parse %q as int16: %v", key, parseErrReason(err))
 		return d
 	}
 	return int16(i16)
+}
+
+// parseErrReason returns the reason of a strconv error (e.g. "invalid syntax" or
+// "value out of range") without the raw input value, which strconv.NumError would
+// otherwise embed in its message. This keeps the (potentially sensitive) environment
+// value out of the logs.
+func parseErrReason(err error) error {
+	var ne *strconv.NumError
+	if errors.As(err, &ne) {
+		return ne.Err
+	}
+	return err
 }

--- a/int_test.go
+++ b/int_test.go
@@ -1,0 +1,46 @@
+package getenv
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntParseErrorDoesNotLogRawValue ensures a failed parse falls back to the
+// default and never writes the raw environment value to the log (the strconv error
+// would otherwise embed it).
+func TestIntParseErrorDoesNotLogRawValue(t *testing.T) {
+	const raw = "garbage-SECRET-value"
+	tests := []struct {
+		name string
+		typ  string
+		call func() interface{}
+		want interface{}
+	}{
+		{"Int", "int", func() interface{} { return Int("NUM_ENV", -10) }, -10},
+		{"Int32", "int32", func() interface{} { return Int32("NUM_ENV", -10) }, int32(-10)},
+		{"Int64", "int64", func() interface{} { return Int64("NUM_ENV", -10) }, int64(-10)},
+		{"Int16", "int16", func() interface{} { return Int16("NUM_ENV", -10) }, int16(-10)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			t.Cleanup(func() { log.SetOutput(os.Stderr) })
+			t.Setenv("NUM_ENV", raw)
+
+			got := tt.call()
+
+			assert.Equal(t, tt.want, got, "should fall back to default")
+			out := buf.String()
+			assert.NotContains(t, out, raw, "raw env value must not be logged")
+			assert.Contains(t, out, "NUM_ENV", "key should be logged")
+			assert.Contains(t, out, "as "+tt.typ, "type should be logged")
+			assert.Contains(t, out, "invalid syntax", "parse reason should be logged")
+		})
+	}
+}


### PR DESCRIPTION
## 概要
パースエラー時のログに、生の環境変数値が漏れないよう修正します。

Closes #20

## 背景と落とし穴
`Int*` はパースエラー時に生の env 値を `log.Printf("parse error: input: %v, ...", v, ...)` で出力していました(#20)。

ただし issue #20 が提案していた素朴な修正 `log.Printf("...%q as int: %v", key, err)` は**不十分**です。`strconv` / `time.ParseDuration` の**エラーメッセージ自体が入力値を埋め込む**ため(例: `strconv.ParseInt: parsing "<生値>": invalid syntax`)、`%v err` でそのまま漏れます。

同じ理由で、**#17 で Duration に追加した env パース失敗ログ**(`time: invalid duration "<生値>"`)も生値を漏らしていました。本 PR で両方まとめて潰します。

## 変更点
- **Int / Int32 / Int64 / Int16**: `strconv.NumError` から**値を含まない理由のみ**(`invalid syntax` / `value out of range`)を抽出する `parseErrReason` を導入。生値も生エラー文字列も出力しない(#20)
  - 例: `getenv: failed to parse "PORT" as int: invalid syntax`(生値なし、理由は保持)
- **Duration(env 側)**: `time` エラーは値なし理由を構造的に取得できないため、**キー名のみ**ログ出力
  - 例: `getenv: failed to parse value for "TIMEOUT" as duration`
- デフォルト値のログ(開発者定数で秘密でない)は従来どおり

## テスト
- `int_test.go` 新規: 全 Int 系で「生値が出ない / キーが出る / 理由(invalid syntax)が出る / デフォルトにフォールバック」を検証(この回帰テストは素朴な修正なら**失敗**します)
- `duration_test.go`: env パース失敗で生値が出ないことを検証 + gofmt 整形
- `go build` / `go vet` / `go test` / `go test -race` すべて ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
