### PR TITLE
go.mod: 宣言バージョンをCI実態に合わせ go 1.21 に更新 (#21)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/ieee0824/getenv
 
-go 1.16
+go 1.21
 
 require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 概要
go.mod の宣言バージョンを、CI で実際にビルド/テストしている版に揃えます。

Closes #21

## 背景
- go.mod は `go 1.16` を宣言する一方、CI(`.go-version`)は **1.21.0** でビルド/テスト → 宣言最小と実テスト版が乖離(#21)
- さらに**全テストが `t.Setenv`(Go 1.17+)を使用**しており、`go 1.16` ではテストがそもそもビルドできない。よって「1.16 サポート」は実態として成立しておらず、issue の「1.16 マトリクス追加」案は**実行不可能**
- → 唯一整合的な選択肢として、宣言を実テスト版に合わせる

## 変更点
- `go` ディレクティブを **1.16 → 1.21**(`.go-version` / CI と一致)
- `go mod tidy` を実行し、間接依存(`go-spew` / `go-difflib` / `yaml.v3`)を明示。`go.sum` も整理(Go 1.17+ のモジュールグラフ刈り込みに対応)

## 検証
- `go build` / `go vet`(tidy 後)/ `go test` / `go test -race` すべて ✅
- `go mod verify`: all modules verified
- ライブラリ本体のコードは概ね stdlib のみで、1.21 固有機能への依存を新たに追加するものではありません(あくまで宣言と実態の整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
