### PR TITLE
bool/stringslice: 想定外入力のサイレントなフォールバックを改善 (#18)

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -62,6 +62,14 @@ fmt.Println(getenv.Duration("ANY_ENV", "1h30m20s"))
 
 `Duration` のデフォルト値は複数の型を受け付けます. **整数(`int`/`int32`/`int64`)と `float64` は「秒」として解釈**され, `time.Duration` はそのまま(ナノ秒)使われます. そのため `getenv.Duration("T", 60)` は 60 秒ですが, `getenv.Duration("T", time.Duration(60))` は 60 *ナノ秒* です(秒で渡すなら `getenv.Duration("T", 60*time.Second)`). 文字列は `time.ParseDuration` でパースされます(例: `"90s"`, `"1h30m"`). 不正な文字列や未対応の型はログ出力して `0` にフォールバックします.
 
+# Bool
+
+`Bool` は `true`/`t`/`1`/`yes`/`on`/`y` を真, `false`/`f`/`0`/`no`/`off`/`n` を偽として解釈します(大文字小文字無視・前後空白 trim). 値がセットされていても認識できない場合は, 無音で false を返さずデフォルト値を維持します(警告ログを出力).
+
+# StringSlice
+
+`StringSlice` はカンマ区切りの値(例: `SOME_ENV=a,b,c`)を分割し, 各要素を trim して空要素を除去します(`"a, b,"` → `["a", "b"]`). 未設定または空文字列のときは, デフォルトがあればそれを, 無ければ空スライスを返します.
+
 # dotenv ダンプ
 
 `GETENV_DUMP_MODE=dotenv` を設定すると、各アクセサが読み取った環境変数ごとに `KEY=` 行を出力します. `.env` テンプレートの生成に便利です.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ fmt.Println(getenv.Duration("ANY_ENV", "1h30m20s"))
 
 `Duration` accepts a default of several types. **Integer defaults (`int`, `int32`, `int64`) and `float64` are interpreted as seconds**, while a `time.Duration` default is used as-is (a nanosecond count). So `getenv.Duration("T", 60)` is 60 seconds, but `getenv.Duration("T", time.Duration(60))` is 60 *nanoseconds* — pass `getenv.Duration("T", 60*time.Second)` instead. String defaults are parsed with `time.ParseDuration` (e.g. `"90s"`, `"1h30m"`); an invalid string or an unsupported default type is logged and falls back to `0`.
 
+# Bool
+
+`Bool` accepts `true`/`t`/`1`/`yes`/`on`/`y` as true and `false`/`f`/`0`/`no`/`off`/`n` as false (case-insensitive, surrounding whitespace trimmed). If the value is set but unrecognised, the default is kept (and a warning is logged) instead of silently returning false.
+
+# StringSlice
+
+`StringSlice` splits a comma-separated value (e.g. `SOME_ENV=a,b,c`), trimming each element and dropping empty ones (so `"a, b,"` becomes `["a", "b"]`). An unset or empty value returns the default when present, otherwise an empty slice.
+
 # dotenv dump
 
 Setting `GETENV_DUMP_MODE=dotenv` makes every accessor emit a `KEY=` line for each

--- a/bool.go
+++ b/bool.go
@@ -1,31 +1,45 @@
 package getenv
 
 import (
+	"log"
 	"os"
 	"strings"
 )
 
-func convertStringToBoolean(s string) bool {
-	s = strings.ToLower(s)
-	switch s {
-	case "true", "t", "1":
-		return true
+// convertStringToBoolean parses common boolean representations, case-insensitively
+// and with surrounding whitespace trimmed. The second return value reports whether s
+// was a recognised boolean; for unrecognised input it is false so the caller can
+// decide how to proceed (e.g. keep a default).
+func convertStringToBoolean(s string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "t", "1", "yes", "on", "y":
+		return true, true
+	case "false", "f", "0", "no", "off", "n":
+		return false, true
 	default:
-		return false
+		return false, false
 	}
 }
 
+// Bool resolves key as a boolean. Recognised truthy values are true/t/1/yes/on/y and
+// falsy values are false/f/0/no/off/n (case-insensitive, trimmed). If the value is set
+// but unrecognised, the default is kept (and a warning is logged) rather than silently
+// returning false.
 func Bool(key string, def ...bool) bool {
 	Logger.Dump(key, def)
 	var d bool
 	if len(def) != 0 {
 		d = def[0]
-	} else {
-		d = false
 	}
 	v, ok := os.LookupEnv(key)
 	if !ok {
 		return d
 	}
-	return convertStringToBoolean(v)
+	b, recognised := convertStringToBoolean(v)
+	if !recognised {
+		// Do not log the raw value, which may be sensitive; the key is enough.
+		log.Printf("getenv: unrecognised bool for %q; keeping default %v", key, d)
+		return d
+	}
+	return b
 }

--- a/bool_test.go
+++ b/bool_test.go
@@ -1,32 +1,70 @@
 package getenv
 
 import (
+	"bytes"
+	"log"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertStringToBoolean(t *testing.T) {
 	tests := []struct {
-		input string
-		want  bool
+		input      string
+		want       bool
+		wantParsed bool
 	}{
-		{"true", true},
-		{"t", true},
-		{"True", true},
-		{"TRUE", true},
-		{"T", true},
-		{"1", true},
-		{"false", false},
-		{"f", false},
-		{"False", false},
-		{"FALSE", false},
-		{"0", false},
-		{"hoge", false},
+		{"true", true, true},
+		{"t", true, true},
+		{"True", true, true},
+		{"TRUE", true, true},
+		{"T", true, true},
+		{"1", true, true},
+		{"yes", true, true},
+		{"on", true, true},
+		{"y", true, true},
+		{"  TRUE  ", true, true},
+		{"false", false, true},
+		{"f", false, true},
+		{"False", false, true},
+		{"FALSE", false, true},
+		{"0", false, true},
+		{"no", false, true},
+		{"off", false, true},
+		{"n", false, true},
+		// unrecognised values report parsed=false
+		{"hoge", false, false},
+		{"2", false, false},
+		{"", false, false},
 	}
 
 	for _, test := range tests {
-		got := convertStringToBoolean(test.input)
-		if got != test.want {
-			t.Fatalf("want %v, but %v:", test.want, got)
-		}
+		got, parsed := convertStringToBoolean(test.input)
+		assert.Equal(t, test.want, got, "value for input %q", test.input)
+		assert.Equal(t, test.wantParsed, parsed, "parsed for input %q", test.input)
 	}
+}
+
+func TestBoolUnrecognisedKeepsDefault(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("FLAG", "maybe-SECRET")
+
+	assert.True(t, Bool("FLAG", true), "unrecognised value should keep default true")
+	assert.False(t, Bool("FLAG", false), "unrecognised value should keep default false")
+
+	out := buf.String()
+	assert.Contains(t, out, "FLAG", "key should be logged")
+	assert.NotContains(t, out, "maybe-SECRET", "raw value must not be logged")
+}
+
+func TestBoolExplicitOverridesDefault(t *testing.T) {
+	t.Setenv("FLAG", "off")
+	assert.False(t, Bool("FLAG", true), "explicit falsy should override default true")
+
+	t.Setenv("FLAG", "yes")
+	assert.True(t, Bool("FLAG", false), "explicit truthy should override default false")
 }

--- a/string.go
+++ b/string.go
@@ -18,8 +18,11 @@ func String(key string, def ...string) string {
 	return v
 }
 
-// env format
-// SOME_ENV=a,b,c,d,e,f
+// StringSlice resolves key as a comma-separated list, e.g. SOME_ENV=a,b,c.
+//
+// Each element is trimmed of surrounding whitespace and empty elements are dropped, so
+// "a, b," yields ["a", "b"]. An unset or empty value is treated the same: the default
+// is returned when present, otherwise an empty (non-nil) slice.
 func StringSlice(key string, def ...[]string) []string {
 	Logger.Dump(key, def)
 	var d []string
@@ -27,12 +30,19 @@ func StringSlice(key string, def ...[]string) []string {
 		d = def[0]
 	}
 	v, ok := os.LookupEnv(key)
-	if !ok {
+	if !ok || v == "" {
 		if len(d) == 0 {
 			return []string{}
 		}
 		return d
 	}
 
-	return strings.Split(v, ",")
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/string_test.go
+++ b/string_test.go
@@ -36,6 +36,31 @@ func TestStringSlice(t *testing.T) {
 			def:    []string{"d", "e", "f"},
 			want:   []string{"a", "b", "c"},
 		},
+		{
+			name:   "env empty string, def empty",
+			envKey: "SOME_ENV",
+			envVal: "",
+			want:   []string{},
+		},
+		{
+			name:   "env empty string, def not empty",
+			envKey: "SOME_ENV",
+			envVal: "",
+			def:    []string{"d", "e", "f"},
+			want:   []string{"d", "e", "f"},
+		},
+		{
+			name:   "trims spaces and drops empty elements",
+			envKey: "SOME_ENV",
+			envVal: " a , b , ,c,",
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name:   "leading and trailing commas",
+			envKey: "SOME_ENV",
+			envVal: ",a,,b,",
+			want:   []string{"a", "b"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## 概要
Bool / StringSlice が想定外入力に対してサイレントにフォールバックする挙動を改善します。

Closes #18

## 背景(監査検出)
- **Bool**: `{true,t,1}` 以外を全て false に潰し、`Bool("X", true)` でも値がセットされていれば誤綴り(`on` 等)で無音 false 化。`def` を無視するフットガン
- **StringSlice**: env が**空文字列**のとき `strings.Split("",",")` で `[""]`(長さ1)を返し、unset 時の `[]`(長さ0)と非対称。`"a,"` の末尾空要素も残る

## 変更点(方針: 許容値拡張 + 未知はデフォルト維持 / 空は[]・trim・空要素除去)
**Bool**
- truthy に `yes`/`on`/`y`、falsy に `no`/`off`/`n`/`false`/`f`/`0` を追加、前後空白 trim・大文字小文字無視
- `convertStringToBoolean` を `(値, 認識可否)` に変更し、**認識できない値はデフォルト値を維持**(+ log 警告)。`def=true` に `maybe` を渡しても無音 false に潰れない
- 明示的な falsy/truthy はデフォルトを上書き(`off`→false、`yes`→true)
- ログに**生値は出さない**(#20 と一貫、キーのみ)

**StringSlice**
- 空文字列の env を unset と同等に扱う(デフォルトがあればデフォルト、無ければ空スライス)
- 非空は分割後に各要素を `TrimSpace` し空要素を除去(`" a , b , ,c,"` → `["a","b","c"]`)

**ドキュメント**: README(en/jp)に両者のセマンティクスを明記

## 後方互換 / 挙動変更
- 既存の正しく綴られた値(`true`/`false` 等)の結果は不変
- **変わる例**: `Bool("X", true)` で `X=garbage` → 従来 false / 変更後 true(デフォルト維持)。`X=yes` → 従来 false / 変更後 true。`StringSlice` の空文字 env → 従来 `[""]` / 変更後 `[]`(or デフォルト)
- いずれも「より直感的で安全な」方向への変更。方針はオーナー確認済み

## テスト
- `bool_test.go` / `string_test.go` を新挙動に合わせ更新・ケース追加(空値・trim・空要素除去・未知値フォールバック・生値非出力)
- `go build` / `go vet` / `go test` / `go test -race` すべて ✅、変更ファイルは gofmt クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
